### PR TITLE
added sync_start.txt to resume failed/stopped download

### DIFF
--- a/lib/download-media.js
+++ b/lib/download-media.js
@@ -87,7 +87,7 @@ const processMediaItemsPageResponse = async (auth, response) => {
 
     for (const mediaItem of mediaItems) {
         if (mediaItem.id === global.STOP_AT) {
-            console.log("No new items to download", mediaItem.id);
+            console.log("Reached end of download job at", mediaItem.id);
             process.exit();
         }
         if (firstPage && firstItem) {

--- a/lib/download-media.js
+++ b/lib/download-media.js
@@ -87,15 +87,37 @@ const processMediaItemsPageResponse = async (auth, response) => {
 
     for (const mediaItem of mediaItems) {
         if (mediaItem.id === global.STOP_AT) {
-            console.log("Reached end of download job at", mediaItem.id);
+            console.log("No new items to download", mediaItem.id);
             process.exit();
         }
         if (firstPage && firstItem) {
             fs.writeFileSync(global.SYNC_STOP_PATH, mediaItem.id);
             console.log(mediaItem.id, "marked as sync stop");
         }
-        await processMediaItem(mediaItem);
+        
+        // in case the download job fails or the access token expires
+        // you can fast forward through the items already downloaded
+        // and then resume the download where the previous run left off
+        if (!global.START_AT) {
+            // if there is no sync_start.txt, then process normally
+            await processMediaItem(mediaItem);
+        } else {  
+            // if there is a sync_start.txt, then keep looping until the last item
+            // from the previous run is found
+            if (mediaItem.id === global.START_AT) {
+                // once it is found, loop one more time to resume download on next item
+                console.log("Previous last downloaded item found");
+                global.lastItemFound = true;
+            } else if (global.lastItemFound) {
+                // download will now resume
+                await processMediaItem(mediaItem);
+            } else {
+                console.log("Previous last item not found, skipping...")
+            }
+        }
+
         firstItem = false;
+        fs.writeFileSync(global.SYNC_START_PATH, mediaItem.id);
     }
 
     if (nextPageToken) {
@@ -136,8 +158,20 @@ const setSyncStop = () => {
     }
 };
 
+const setSyncStart = () => {
+    global.SYNC_START_PATH = path.resolve(__dirname, "../sync-start.txt");
+
+    try {
+        global.START_AT = fs.readFileSync(global.SYNC_START_PATH).toString();
+    } catch (err) {
+        console.log("Did not find sync-start.txt. Continuing...");
+    }
+};
+
 const downloadMedia = auth => {
+    global.lastItemFound = false;
     setSyncStop();
+    setSyncStart();
     getMediaItemsPage(auth);
 };
 


### PR DESCRIPTION
Matt, what do you think about this change to resume a download using a sync_start.txt file? See processMediaItemsPageResponse comments for explanation.